### PR TITLE
titus2 is now available on PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ sudo: required
 dist: xenial
 install: 
   - pip install .[test]
-  - pip install git+https://github.com/animator/python3-titus#egg=titus
+  - pip install titus2
 script: pytest


### PR DESCRIPTION
The package is now officially available via PyPI with regular releases.
https://pypi.org/project/titus2/